### PR TITLE
Allow specification of extra kwargs to Runner.

### DIFF
--- a/pytest_ansible/plugin.py
+++ b/pytest_ansible/plugin.py
@@ -160,6 +160,9 @@ class AnsibleModule(object):
         # Log the module and parameters
         log.debug("[%s] %s: %s, %s" % (self.pattern, self.module_name, module_args, kwargs))
 
+        # Pull out extra arguments for the Runner
+        extra_runner_kwargs = kwargs.pop('_runner_kwargs', {})
+
         # Build module runner object
         kwargs = dict(
             inventory=self.inventory_manager,
@@ -182,6 +185,9 @@ class AnsibleModule(object):
                 sudo=self.options.get('sudo'),
                 sudo_user=self.options.get('sudo_user'),)
             )
+
+        # Fold in extra arguments
+        kwargs.update(extra_runner_kwargs)
 
         runner = ansible.runner.Runner(**kwargs)
 

--- a/test_pytest_ansible.py
+++ b/test_pytest_ansible.py
@@ -193,3 +193,20 @@ class Test_Fixture_Scope(object):
         # assert a single contacted host ...
         assert contacted and len(contacted) == 1
         assert 'localhost' in contacted
+
+
+@pytest.mark.ansible(host_pattern='localhost', connection='local')
+def test_extra_runner_kwargs(ansible_module, tmpdir):
+    '''Extra arguments in _runner_kwargs are passed along to the Runner
+    '''
+    contacted = ansible_module.file(
+        path=tmpdir.strpath, state='absent',
+        _runner_kwargs={
+            'check': True,
+        })
+
+    # Since this was run in check mode, the tmpdir will still exist.
+    assert tmpdir.exists()
+    localhost = contacted['localhost']
+    assert not localhost.get('failed')
+    assert localhost.get('changed')

--- a/test_pytest_ansible.py
+++ b/test_pytest_ansible.py
@@ -368,18 +368,26 @@ def test_dark_with_debug_enabled(testdir, option):
     ])
 
 
-@pytest.mark.ansible(host_pattern='localhost', connection='local')
-def test_extra_runner_kwargs(ansible_module, tmpdir):
+def test_extra_runner_kwargs(testdir, option):
     '''Extra arguments in _runner_kwargs are passed along to the Runner
     '''
-    contacted = ansible_module.file(
-        path=tmpdir.strpath, state='absent',
-        _runner_kwargs={
-            'check': True,
-        })
+    src = '''
+        import pytest
+        def test_func(ansible_module, tmpdir):
+            contacted = ansible_module.file(
+                path=tmpdir.strpath, state='absent',
+                _runner_kwargs={
+                    'check': True,
+                })
 
-    # Since this was run in check mode, the tmpdir will still exist.
-    assert tmpdir.exists()
-    localhost = contacted['localhost']
-    assert not localhost.get('failed')
-    assert localhost.get('changed')
+            # Since this was run in check mode, the tmpdir will still exist.
+            assert tmpdir.exists()
+            localhost = contacted['localhost']
+            assert not localhost.get('failed')
+            assert localhost.get('changed')
+    '''
+    testdir.makepyfile(src)
+    result = testdir.runpytest(*option.args + ['--ansible-inventory', str(option.inventory),
+                                               '--ansible-host-pattern', 'local'])
+    assert result.ret == EXIT_OK
+    assert result.parseoutcomes()['passed'] == 1


### PR DESCRIPTION
This means that tests can do things like run modules in check mode or request a diff. It's useful in some tests I've written.