### PR TITLE
Don't assume pytestmark is iterable

### DIFF
--- a/pytest_ansible/plugin.py
+++ b/pytest_ansible/plugin.py
@@ -3,6 +3,7 @@ import logging
 from pkg_resources import parse_version
 from .fixtures import (ansible_module_cls, ansible_module, ansible_facts_cls, ansible_facts)
 from .errors import AnsibleNoHostsMatch, AnsibleHostUnreachable
+import collections
 
 # conditionally import ansible libraries
 import ansible
@@ -219,7 +220,7 @@ class PyTestAnsiblePlugin:
             if hasattr(request.function, 'ansible'):
                 return request.function.ansible.kwargs
         elif request.scope == 'class':
-            if hasattr(request.cls, 'pytestmark'):
+            if hasattr(request.cls, 'pytestmark') and isinstance(request.cls.pytestmark, collections.Iterable):
                 for pytestmark in request.cls.pytestmark:
                     if pytestmark.name == 'ansible':
                         return pytestmark.kwargs


### PR DESCRIPTION
When a test class uses `pytest.mark.usefixtures("fixture_one", "fixture_two")` and no custom markers a TypeError occurs:

```
Traceback (most recent call last):
  File ".../pytest_ansible/fixtures.py", line 27, in ansible_module_cls
    return ansible_helper.initialize(request)
  File ".../pytest_ansible/plugin.py", line 253, in initialize
    marker_kwargs = self._get_marker_kwargs(request)
  File ".../pytest_ansible/plugin.py", line 224, in _get_marker_kwargs
    for pytestmark in request.cls.pytestmark:
TypeError: iteration over non-sequence
```

This PR makes an iterable check to prevent this.